### PR TITLE
Update community roles to be more specific

### DIFF
--- a/community-roles.md
+++ b/community-roles.md
@@ -5,9 +5,8 @@ and the responsibilities associated with each role, where applicable.
 - [Community Leader](#community-leader)
 - [Community Manager](#community-manager)
 - [Repositories Manager](#repository-manager)
-- [Solid Core Contributor](#solid-core-contributor)
-- [Project Core Contributor](#project-core-contributor)
 - [Project Release Manager](#project-release-manager)
+- [Project Core Contributor](#project-core-contributor)
 - [User Testing Panel Coordinator](#user-testing-panel-coordinator)
 - [Solid User Testing Panelist](Solid-user-testing-panelist)
 - [Solid Event Organiser](Solid-Event-Organiser) 
@@ -21,22 +20,19 @@ The Community Leader defines the governing vision of the Solid project, and chan
 ## Repositories Manager
 The Repositories Manager controls Github, NPM, and other Solid organisation properties related to the storage, management, and distribution of official Solid projects. They are responsible for keeping these properties clean and well-organised on behalf of the Solid community. The Repositories Manager has admin rights of Solid tools must attend the weekly recurring community support meeting.
 
-## Solid Core Contributor
-Solid Core Contributors work across projects on initiatives that enrich the Solid ecosystem as a whole. Solid Core Contributors must attend the weekly recurring community support meeting.
+## Project Release Manager
+The Project Release Managers are responsible for determining which features and/or bug-fixes will be merged into the release of their respective [projects](https://github.com/orgs/solid/projects). Project release managers must attend the weekly recurring community support meeting. The Project Release Manager of a specific [project](https://github.com/orgs/solid/projects) is reposible for leading that project. 
 
 ## Project Core Contributor
 A Project Core Contributor is a key team member on an official Solid project.
 They may have issues assigned to them, review and merge pull requests, and must
 attend regular stand-ups and project strategy meetings.
 
-## Project Release Manager
-The Project Release Managers are responsible for determining which features and/or bug-fixes will be merged into the release of their respective projects. Project release managers must attend the weekly recurring community support meeting.
-
 ## User Testing Panel Coordinator
 Panel Coordinators are responsible for designing and running tests with the Solid Panelists as well as publishing test results to the Solid community. Panel Coordinators are expected to join the weekly user testing meeting which is moderated by the Community Manager.
 
 ## Solid User Testing Panelist
-Solid Panelists are individuals who are available for a range of tests over time to improve the Solid user experience. When there is a test set up by the Panel Coordinators, the Community Manager will reach out to the relevant Solid Panelists to ask if they would like to participate in that particular test. Each test will take approximately 30 minutes, Solid Panelists are not obliged to participate in all tests, and Solid Panelists can stop being on the Solid Panel at any point. Tests will be designed to improve the Solid experience.
+Solid Panelists are individuals who are available for a range of tests over time to improve the Solid user experience. When there is a test set up by the Panel Coordinators, the Community Manager will reach out to the relevant Solid Panelists to ask if they would like to participate in that particular test. Each test will take approximately 30 minutes, Solid Panelists are not obliged to participate in all tests, and Solid Panelists can stop being on the Solid Panel at any point. Tests will be designed to improve the Solid experience. Solid User Testing Panelists do not take part in the community support meeting nor in the solid/team gitter chat to avoid bias during the test.
 
 ## Solid Event Organiser
 The [Solid Event](solid-events.md) Organiser is responsible for organising and coordinatiing a Solid Event in a stated city. The position of Solid Event Organiser will be filled by an individual for as long as an event is scheduled in the future.
@@ -45,8 +41,13 @@ The [Solid Event](solid-events.md) Organiser is responsible for organising and c
 
 * **Community Leader** - [Tim Berners-Lee](https://github.com/timbl)
 * **Community Manager** - [Mitzi László](https://github.com/Mitzi-Laszlo)
-* **Repository Manager** - [Kjetil Kjernsmo](https://github.com/kjetilk)
-* **Project Release Manager** - [Kjetil Kjernsmo](https://github.com/kjetilk)
-* **Solid Core Contributors** - [Ruben Verborgh](https://github.com/RubenVerborgh), [Arne Hassel](https://github.com/megoth_twitter), [Justin Bingham](https://github.com/justinwb), [Kjetil Kjernsmo](https://github.com/kjetilk)
+* **Repositories Manager** - [Kjetil Kjernsmo](https://github.com/kjetilk)
+* **Project Release Manager** 
+ASAP on Server - [Kjetil Kjernsmo](https://github.com/kjetilk)
+NSS - 5.0.0  - [Kjetil Kjernsmo](https://github.com/kjetilk)
+* **Project Core Conntributor** 
+ASAP on Server - [[Arne Hassel](https://github.com/megoth_twitter)
+NSS - 5.0.0  - [Arne Hassel](https://github.com/megoth_twitter)
 * **User Testing Panel Coordinator** - [Maya Rinehart](https://github.com/mayarhinehart), [Felix Poon](https://github.com/fcfpoon), [Tony Morelli](https://github.com/tony-morelli)
-* **Solid Panelist** - Eric Prud’hommeaux, Eduardo Ibacache Rodriguez, Teodora Petkova,  David Booth, Pat McBennett
+* **Solid User Testing Panelist** - Eric Prud’hommeaux, Eduardo Ibacache Rodriguez, Teodora Petkova,  David Booth, Pat McBennett
+* **Solid Event Organiser** - see upcoming organisers for upcoming [Solid Events](solid-events.md) 


### PR DESCRIPTION
Link to specific projects included. 

Project Release Managers should be explicitly responsible for leading a specific project. @kjetilk 

Include Project Core Contributor as @megoth 

Perhaps the Solid Core Contributors should be included as Project Core Contributors instead? As in, if you are not working on a project or managing a repository, what other contributions would you be focusing on?

Repositories Manager per repository needs to be updated according to https://github.com/solid/community/issues/10 

Include a link to Solid Event Organisers individuals