### PR TITLE
Remove duplicate and correct date

### DIFF
--- a/solid-resources.md
+++ b/solid-resources.md
@@ -6,11 +6,9 @@
 
 20190203 - [FOSDEM: Solid: taking back the Web through decentralization](https://rubenverborgh.github.io/Slides-FOSDEM-2019/)
 
-20180528 - [ACM Turing Lecture - Utopia to Dystopia in 29 short years](https://www.w3.org/2018/Talks/0529-timbl-turing/timbl-turing-slides-utopia-to-dystopia.html)
+20180802 [Decentralized Web Summit](https://solid.github.io/dweb-summit-2018/) USA
 
 20180528 - [ACM Turing Lecture - Utopia to Dystopia in 29 short years](https://www.w3.org/2018/Talks/0529-timbl-turing/timbl-turing-slides-utopia-to-dystopia.html)
-
-20180202 [Decentralized Web Summit](https://solid.github.io/dweb-summit-2018/) USA
 
 20171212 [CNI Fall 2017 Meeting - Herbert van der Sompel](https://www.slideshare.net/hvdsomp/paul-evan-peters-lecture/)
 


### PR DESCRIPTION
Remove one of two duplicate entries for the ACM Turing Lecture.
Correct date for the Decentralized Web Summit from 2 Feb '18 to 2 Aug '18 and move it up to maintain chronology.