### PR TITLE
Fix invalid links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@
 This community repository is designed to give an overview of [Solid](https://github.com/solid) and describe how to engage. 
 
 ## Table of Contents
- * [Specifications](##Specifications)
- * [Examples](##Examples)
- * [Licensing](##Licensing)
- * [Solid Logo](##solid-logo)
- * [Resources](##resources)
- * [Providers](##providers) 
+ * [Specifications](#Specifications)
+ * [Examples](#Examples)
+ * [Licensing](#Licensing)
+ * [Solid Logo](#solid-logo)
+ * [Resources](#resources)
+ * [Providers](#providers)
  * [The Solid Team](#the-solid-team)
- * [Community Support Meetings](##community-support-meetings)
- * [Advisory Board](##advisory-board)
+ * [Community Support Meetings](#community-support-meetings)
+ * [Advisory Board](#advisory-board)
  * [How to Contribute](#how-to-contribute)
- * [Solid Conversations](##solid-conversations)
- * [Solid Events](##solid-events)
- * [Public Speaking](##public-speaking)
- * [User Testing](##user-testing)
+ * [Solid Conversations](#solid-conversations)
+ * [Solid Events](#solid-events)
+ * [Public Speaking](#public-speaking)
+ * [User Testing](#user-testing)
 
 ## Specifications
  Terms used in the Solid specifications are defined in the [Solid Dictionary](https://github.com/solid/community/blob/master/solid-dictionary.md) and a full overview of the [architecture](https://github.com/solid/solid-architecture) explains how the Solid specifications are interrelated. 
@@ -69,7 +69,7 @@ Solid has a [code of conduct](code-of-conduct.md) which all community members mu
 
 ## Processes 
 Step 1. Making a Suggestion
-	Submit a GitHub pull request if you would like to make a specific change to code or text or a [issue](https://github.com/solid/community/blob/master/issue-template.md) if you would like to raise a general point. Assign the appropriate labels by listing them in the optional extend description. 
+	Submit a GitHub pull request if you would like to make a specific change to code or text or a [issue](https://github.com/solid/community/tree/master/.github/ISSUE_TEMPLATE) if you would like to raise a general point. Assign the appropriate labels by listing them in the optional extend description.
  
  Step 2. Inviting a Conversation around your Suggestion to Find Consensus
 	Let others know about your suggestion by posting it on [solid/suggestions](https://gitter.im/solid/suggestions). Solid/suggestions is not a place to talk about the suggestion, this happens in the pull request or issue itself. Leave the pull request or issue open for two weeks to give others in the Solid community the opportunity to share ideas and propose solutions. 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 This community repository is designed to give an overview of [Solid](https://github.com/solid) and describe how to engage. 
 
 ## Table of Contents
- * [Specifications](#Specifications)
- * [Examples](#Examples)
- * [Licensing](#Licensing)
+ * [Specifications](#specifications)
+ * [Examples](#examples)
+ * [Licensing](#licensing)
  * [Solid Logo](#solid-logo)
  * [Resources](#resources)
  * [Providers](#providers)
@@ -15,7 +15,7 @@ This community repository is designed to give an overview of [Solid](https://git
  * [How to Contribute](#how-to-contribute)
  * [Solid Conversations](#solid-conversations)
  * [Solid Events](#solid-events)
- * [Public Speaking](#public-speaking)
+ * [Press](#press)
  * [User Testing](#user-testing)
 
 ## Specifications

--- a/associations.md
+++ b/associations.md
@@ -3,7 +3,7 @@
 * [Tim Berners-Lee](https://github.com/timbl): co-founder of inrupt
 * [Mitzi László](https://github.com/Mitzi-Laszlo): communications manager at inrupt, ethics auditor at European Commissions
 * [Kjetil Kjernsmo](https://github.com/kjetilk): senior developer at inrupt
-* [Arne Hassel](https://github.com/megoth_twitter): senior developer at inrupt
+* [Arne Hassel](https://github.com/megoth): senior developer at inrupt
 * [Ruben Verborgh](https://github.com/RubenVerborgh): professor at the University of Ghent
 * [Justin Bingham](https://github.com/justinwb): co-founder of Janeiro Digital working with inrupt
 * [Maya Rinehart](https://github.com/mayarhinehart):user experience designer at Janeiro Digital working with inrupt

--- a/becoming-a-solid-provider.md
+++ b/becoming-a-solid-provider.md
@@ -4,13 +4,13 @@ To become a Solid Provider the requirements are full accurate transparency on:
 * use of data if any by who and for what ideally in the form of complete terms and conditions and a privacy policy
 
 # POD Provider 
-[Publish the details of your POD]((https://github.com/solid/community/blob/master/solid-apps.md) including: name of POD, link to the POD, entity responisble for the POD domain, location of hosting 
+[Publish the details of your POD](https://github.com/solid/solid-apps) including: name of POD, link to the POD, entity responisble for the POD domain, location of hosting
 
 # WebID Provider
-[Publish the details of your POD]((https://github.com/solid/community/blob/master/solid-apps.md) including: name of WebID , link to the WebID, entity responisble for the WebID domain, location of hosting
+[Publish the details of your POD](https://github.com/solid/solid-apps) including: name of WebID , link to the WebID, entity responisble for the WebID domain, location of hosting
 
 # Solid App Provider
-[Publish the details of your Solid app](https://github.com/solid/community/blob/master/solid-apps.md)including: name of app, link to app, description of app, name of app provider, any licensing information, description of what data is used by who and for what 
+[Publish the details of your Solid app](https://github.com/solid/solid-apps) including: name of app, link to app, description of app, name of app provider, any licensing information, description of what data is used by who and for what
 
 # Developer Tool Provider 
-[Publish the details of your developer support tools](https://github.com/solid/developer-support-tools.md) including: name of developer support tools , link to the developer support toold, name of entity responisble for developer support tools
+[Publish the details of your developer support tools](https://github.com/solid/community/blob/master/developer-tools.md) including: name of developer support tools , link to the developer support toold, name of entity responisble for developer support tools

--- a/community-roles.md
+++ b/community-roles.md
@@ -47,8 +47,8 @@ Find out any [associations](associations.md) individuals occupying these roles h
 ASAP on Server - [Kjetil Kjernsmo](https://github.com/kjetilk)
 NSS - 5.0.0  - [Kjetil Kjernsmo](https://github.com/kjetilk)
 * **Project Core Contributor** 
-ASAP on Server - [[Arne Hassel](https://github.com/megoth_twitter)
-NSS - 5.0.0  - [Arne Hassel](https://github.com/megoth_twitter)
+ASAP on Server - [[Arne Hassel](https://github.com/megoth)
+NSS - 5.0.0  - [Arne Hassel](https://github.com/megoth)
 * **User Testing Panel Coordinator** - [Maya Rinehart](https://github.com/mayarhinehart), [Felix Poon](https://github.com/fcfpoon), [Tony Morelli](https://github.com/tony-morelli)
 * **Solid User Testing Panelist** - Eric Prud’hommeaux, Eduardo Ibacache Rodriguez, Teodora Petkova,  David Booth, Pat McBennett
 * **Solid Event Organiser** - see upcoming organisers for upcoming [Solid Events](solid-events.md) 

--- a/solid-resources.md
+++ b/solid-resources.md
@@ -14,7 +14,7 @@
 
 20160407 [IPRI meeting](https://slides.com/deiu/redecentralize-2015#/) and [slides](slides-redecentralize-conf.html)
 
-20160324 [W3C Developers Meetup](http://www.meetup.com/W3C-developers-in-Boston/events/229580827/) - [view](https://slides.com/deiu/redecentralize-2015#/) - [source](slides-redecentralize-conf.html)
+20160324 W3C Developers Meetup in Boston - [view](https://slides.com/deiu/redecentralize-2015#/) - [source](slides-redecentralize-conf.html)
 
 20151018 [Redecentralize conference](https://slides.com/deiu/redecentralize-2015#/) - [source](slides-redecentralize-conf.html) - [video](https://www.youtube.com/watch?v=yi4SgNyDJ9w)
 

--- a/status.md
+++ b/status.md
@@ -22,7 +22,7 @@ Future
 * 28th March: Ruben will attend [Beyond Data](https://www.smart-circle.org/beyonddata/program/) in Eindhoven 
 * 4th April: Ruben will attend [STRP Festival](https://strp.nl/program/ruben-verborgh-be) in Eindhoven
 
-## [Solid Apps](https://github.com/solid/community/blob/master/solid-apps.md)
+## [Solid Apps](https://github.com/solid/solid-apps)
 * [Form Router] by Form Router inc to submit and extract data from a Pod (please send feedback to jim@formrouter.com)
 * A-PHEVOS by Aditya Shukla derived from Photo, Event, Organise and Share is an alpha version of a POD manager
 

--- a/status.md
+++ b/status.md
@@ -45,7 +45,7 @@ Future
 * 1st - 3rd March: Mitzi will be attending [Rebooting the Web of Trust](https://www.weboftrust.info/next-event-page.html) in Barcelona 
 * 6th March: Kjetil will be attending Your Digital Identity Norway in Oslo
 
-## [Solid Apps](https://github.com/solid/community/blob/master/solid-apps.md)
+## [Solid Apps](https://github.com/solid/solid-apps)
 * [Tiddlywiki](https://bourgeoa.solid.community/public/tiddlywiki/) by Bourgeoa
 * [Solid IDE](https://jeff-zucker.github.io/solid-ide/?url=https://solside.solid.community/public/samples/index.html) by Jeff Zucker as a file browser
  


### PR DESCRIPTION
Hi!
Thanks for the helpful documentation as I've been able to quickly get a pulse on the community. Solid looks exciting. I noticed a couple links were invalid so I ran [this tool](https://www.npmjs.com/package/markdown-link-validator) and got the following output:

```
Found a total of 178 links in directory "/Users/me/code/repo/community":
    156 valid
    22 invalid
```

I have fixed all of the invalid links except for the repository manager link which is fixed in #44. I could fix that in this PR if you'd like. 

To prevent future invalid links, I'd recommend setting this up to run on every commit via a CI tool like travis. I'd be happy to set that up if desired. I'm guessing from the community roles that kjetilk would be the one to ask about CI access

Cheers, Gabriel